### PR TITLE
fix(commands): use NL postage constant in generate-bulktest-data

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -30,7 +30,7 @@ from app.celery.letters_pdf_tasks import (
 )
 from app.celery.tasks import get_id_task_args_kwargs_for_job_row, process_job_row
 from app.config import QueueNames
-from app.constants import KEY_TYPE_TEST, NOTIFICATION_CREATED, SMS_TYPE
+from app.constants import KEY_TYPE_TEST, NETHERLANDS, NOTIFICATION_CREATED, SMS_TYPE
 from app.dao.annual_billing_dao import (
     dao_create_or_update_annual_billing_for_year,
     set_default_free_allowance_for_service,
@@ -904,7 +904,7 @@ def generate_bulktest_data(user_id):
             template_type="letter",
             subject="letter",
             content="letter body",
-            postage="second",
+            postage=NETHERLANDS,
             created_by_id=user_id,
         ),
     }
@@ -928,7 +928,7 @@ def generate_bulktest_data(user_id):
         for i in range(batch_size):
             notification_num = (batch * batch_size) + i
             notification_type = random.choice(["sms", "letter", "email"])
-            extra_kwargs = {"postage": "second"} if notification_type == "letter" else {}
+            extra_kwargs = {"postage": NETHERLANDS} if notification_type == "letter" else {}
             template = TEMPLATES[notification_type]
             notifications_batch.append(
                 Notification(

--- a/migrations_nl/versions/0018_fix_legacy_postage_values.py
+++ b/migrations_nl/versions/0018_fix_legacy_postage_values.py
@@ -1,0 +1,44 @@
+"""fix legacy postage values
+
+Revision ID: 0018
+Revises: 0017
+Create Date: 2026-07-31 09:00:00.000000
+
+"""
+from alembic import op
+from sqlalchemy import text
+
+
+# revision identifiers, used by Alembic.
+revision = '0018'
+down_revision = '0017'
+branch_labels = None
+depends_on = None
+
+
+VALID_POSTAGE_TYPES = ('netherlands', 'europe', 'rest-of-world')
+NETHERLANDS = 'netherlands'
+
+# 'first' and 'second' are upstream's old UK domestic postage tiers, both of
+# which map onto our single domestic tier, 'netherlands'.
+tables = ('templates', 'templates_history', 'notifications', 'notification_history')
+
+update_postage_sql = """
+    UPDATE {}
+    SET postage = :postage
+    WHERE postage NOT IN :valid_postage_types"""
+
+
+def upgrade():
+    for table in tables:
+        op.execute(
+            text(update_postage_sql.format(table)).bindparams(
+                postage=NETHERLANDS,
+                valid_postage_types=VALID_POSTAGE_TYPES,
+            )
+        )
+
+
+def downgrade():
+    # Original per-row values ('first' vs 'second') aren't recoverable.
+    pass


### PR DESCRIPTION
This command still had upstream's hardcoded "second" postage value, which isn't one of our NL postage types and throws a KeyError when it tries to build the PDF filename for the templates it creates.